### PR TITLE
update openapi response to add html parameters

### DIFF
--- a/stac_fastapi/html/middleware.py
+++ b/stac_fastapi/html/middleware.py
@@ -183,6 +183,9 @@ class HTMLRenderMiddleware:
                 encode_to_html = True
 
             response_headers = MutableHeaders(scope=start_message)
+
+            # stac-fastapi application overwrite the content-type for
+            # openapi response and use "application/vnd.oai.openapi+json;version=3.0"
             if (
                 response_headers.get("Content-Type")
                 == "application/vnd.oai.openapi+json;version=3.0"

--- a/stac_fastapi/html/middleware.py
+++ b/stac_fastapi/html/middleware.py
@@ -84,7 +84,7 @@ class HTMLRenderMiddleware:
 
     app: ASGIApp
     templates: Jinja2Templates = field(default_factory=lambda: DEFAULT_TEMPLATES)
-    endpoints_names: dict[str, str] = field(default_factory=lambda: ENDPOINT_TEMPLATES)
+    endpoint_names: dict[str, str] = field(default_factory=lambda: ENDPOINT_TEMPLATES)
 
     def create_html_response(
         self,
@@ -194,7 +194,7 @@ class HTMLRenderMiddleware:
                 for _, path in openapi_doc.get("paths").items():
                     if (
                         path.get("get", {}).get("summary", "").lower()
-                        in self.endpoints_names
+                        in self.endpoint_names
                     ):
                         if "parameters" not in path["get"]:
                             path["get"]["parameters"] = []
@@ -230,7 +230,7 @@ class HTMLRenderMiddleware:
             elif start_message["status"] == 200 and encode_to_html:
                 # NOTE: `scope["route"]` seems to be specific to FastAPI application
                 if route := scope.get("route"):
-                    if tpl := self.endpoints_names.get(route.name.lower()):
+                    if tpl := self.endpoint_names.get(route.name.lower()):
                         body = self.create_html_response(
                             request,
                             json.loads(body.decode()),


### PR DESCRIPTION
closes #3 

intercept `openapi` response from stac-fastapi and update the query-parameters and accepted headers

```
# before
curl http://127.0.0.1:8000/api | jq '.paths."/"'
{
  "get": {
    "summary": "Landing Page",
    "description": "Endpoint.",
    "operationId": "Landing_Page__get",
    "responses": {
      "200": {
        "description": "Successful Response",
        "content": {
          "application/json": {
            "schema": {
              "$ref": "#/components/schemas/LandingPage"
            }
          }
        }
      }
    }
  }
}


# now
curl http://127.0.0.1:8000/api | jq '.paths."/"'
{
  "get": {
    "summary": "Landing Page",
    "description": "Endpoint.",
    "operationId": "Landing_Page__get",
    "responses": {
      "200": {
        "description": "Successful Response",
        "content": {
          "application/json": {
            "schema": {
              "$ref": "#/components/schemas/LandingPage"
            }
          },
          "text/html": {}
        }
      }
    },
    "parameters": [
      {
        "name": "f",
        "in": "query",
        "required": false,
        "schema": {
          "anyOf": [
            {
              "enum": [
                "html"
              ],
              "type": "string"
            },
            {
              "type": "null"
            }
          ],
          "description": "Response MediaType.",
          "title": "F"
        },
        "description": "Response MediaType."
      }
    ]
  }
}
```
<img width="1215" alt="Screenshot 2025-03-25 at 3 16 44 PM" src="https://github.com/user-attachments/assets/07b53933-fbfd-4ba1-b654-6f2d72a2334b" />

